### PR TITLE
Bump YamlDotNet dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Yayaml
 
+## v0.2.0 - TBD
+
++ Updated [YamlDotNet](https://github.com/aaubry/YamlDotNet) dependency to `13.4.0`
+
 ## v0.1.1 - 2023-08-03
 
 + Treat `IntPtr` values like other numeric types

--- a/module/Yayaml.psd1
+++ b/module/Yayaml.psd1
@@ -15,7 +15,7 @@
     # RootModule = 'bin/net6.0/Yayaml.dll'
 
     # Version number of this module.
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Yayaml.Module/Yayaml.Module.csproj
+++ b/src/Yayaml.Module/Yayaml.Module.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
-    <PackageReference Include="YamlDotNet" Version="13.1.1" />
+    <PackageReference Include="YamlDotNet" Version="13.4.0" />
     <ProjectReference Include="../Yayaml/Yayaml.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps the YamlDotNet dependency to 13.4.0. This includes some performance fixes around string allocations and fixes parsing Unicode characters that are surrogate pairs like emojis. There may be other fixes or improvements included with this dependency upgrade.

Fixes: https://github.com/jborean93/PowerShell-Yayaml/issues/4