### PR TITLE
Add support for Span and Memory types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Yayaml
 
+## v0.2.1 - TBD
+
++ Support serializating dotnet properties that return a `Span<T>`, `ReadOnlySpan<T>`, `Memory<T>`, or `ReadOnlyMemory<T>`
+  + These values will be copied to a temporary array of the type `T`
++ Treat any `IList<byte>` type, not just `byte[]`, as `!!binary` with the `Yaml11` schema
+
 ## v0.2.0 - 2023-09-26
 
 + Updated [YamlDotNet](https://github.com/aaubry/YamlDotNet) dependency to `13.4.0`

--- a/module/Yayaml.psd1
+++ b/module/Yayaml.psd1
@@ -15,7 +15,7 @@
     # RootModule = 'bin/net6.0/Yayaml.dll'
 
     # Version number of this module.
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.2.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Yayaml.Module/ReflectionHelper.cs
+++ b/src/Yayaml.Module/ReflectionHelper.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Yayaml.Module;
+
+internal static class ReflectionHelper
+{
+    private static ModuleBuilder? _builder;
+    private static Dictionary<string, MethodInfo> _spanDelegates = new();
+
+    private static ModuleBuilder Module
+    {
+        get
+        {
+            if (_builder == null)
+            {
+                const string assemblyName = "Yayaml.Module.Dynamic";
+                AssemblyBuilder builder = AssemblyBuilder.DefineDynamicAssembly(
+                    new(assemblyName),
+                    AssemblyBuilderAccess.Run);
+
+                _builder = builder.DefineDynamicModule(assemblyName);
+            }
+
+            return _builder;
+        }
+    }
+
+    /// <summary>
+    /// You cannot use reflection to get a Span value, this will define a
+    /// dynamic method to get the span property and call ToArray() on the value
+    /// to convert the span to an array for serialization.
+    /// </summary>
+    /// <param name="obj">The object the property is on.</param>
+    /// <param name="spanProp">The property to get the span value for.</param>
+    /// <returns>The span as an array.</returns>
+    public static Array SpanToArray(object obj, PropertyInfo spanProp)
+    {
+        Type objType = obj.GetType();
+        string delegateId = $"{objType.FullName}{spanProp.Name}_Get";
+        Console.WriteLine(delegateId);
+
+        MethodInfo? toArrayMeth;
+        if (!_spanDelegates.TryGetValue(delegateId, out toArrayMeth))
+        {
+            Type spanType = spanProp.PropertyType;
+            MethodInfo spanToArrayMeth = spanType.GetMethod(
+                "ToArray",
+                BindingFlags.Public | BindingFlags.Instance,
+                Array.Empty<Type>()
+            )!;
+
+            const string invokeMethName = "Invoke";
+            TypeBuilder tb = Module.DefineType(
+                delegateId,
+                TypeAttributes.NotPublic,
+                null
+            );
+            MethodBuilder mb = tb.DefineMethod(
+                invokeMethName,
+                MethodAttributes.Static | MethodAttributes.Private,
+                CallingConventions.Standard,
+                typeof(Array),
+                new[] { objType }
+            );
+            mb.DefineParameter(0, ParameterAttributes.None, "arg0");
+            mb.DefineParameter(1, ParameterAttributes.None, "obj");
+
+            ILGenerator il = mb.GetILGenerator();
+            LocalBuilder spanLocal = il.DeclareLocal(spanType);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, spanProp.GetGetMethod()!);
+            il.Emit(OpCodes.Stloc, spanLocal);
+            il.Emit(OpCodes.Ldloca, spanLocal);
+            il.Emit(OpCodes.Call, spanToArrayMeth);
+            il.Emit(OpCodes.Ret);
+
+            Type dynamicType = tb.CreateType()!;
+            toArrayMeth = dynamicType.GetMethod(
+                invokeMethName,
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+            _spanDelegates[delegateId] = toArrayMeth;
+        }
+
+        return (Array)toArrayMeth.Invoke(null, new[] { obj })!;
+    }
+}

--- a/src/Yayaml/Yaml11Schema.cs
+++ b/src/Yayaml/Yaml11Schema.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.Linq;
-using System.Management.Automation;
 using System.Numerics;
 using System.Text.RegularExpressions;
 
@@ -79,7 +79,7 @@ $)
 ", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
 
     public override bool IsScalar(object? value)
-        => value is byte[];
+        => value is IList<byte>;
 
     public override ScalarValue EmitScalar(object? value)
     {
@@ -107,9 +107,9 @@ $)
                 Tag = noTag ? null : "!!timestamp",
             };
         }
-        else if (value is byte[] byteArray)
+        else if (value is IList<byte> byteArray)
         {
-            return new ScalarValue(Convert.ToBase64String(byteArray))
+            return new ScalarValue(Convert.ToBase64String(byteArray.ToArray()))
             {
                 Tag = "!!binary",
             };

--- a/src/Yayaml/Yaml12JSONSchema.cs
+++ b/src/Yayaml/Yaml12JSONSchema.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Globalization;
 using System.Linq;
-using System.Management.Automation;
 using System.Numerics;
 using System.Text.RegularExpressions;
 
@@ -50,7 +49,7 @@ $
         if (commonScalar != null)
         {
             // If the values are a NaN or +/-Infinity they need to be tagged.
-            if ((new[] {".nan", ".inf", "-.inf"}).Contains(commonScalar.Value))
+            if ((new[] { ".nan", ".inf", "-.inf" }).Contains(commonScalar.Value))
             {
                 commonScalar.Tag = "!!float";
             }
@@ -68,10 +67,10 @@ $
 
     public override SequenceValue EmitSequence(object?[] values)
     {
-         return new(values)
-         {
+        return new(values)
+        {
             Style = CollectionStyle.Flow
-         };
+        };
     }
 
     public override object? ParseScalar(ScalarValue value) => value.Tag switch

--- a/src/Yayaml/Yaml12Schema.cs
+++ b/src/Yayaml/Yaml12Schema.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using System.Management.Automation;
 using System.Numerics;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
Adds support for serializing any Span, Memory, or their ReadOnly* variants. These types are treated as a plain array copy of the underlying value.

This commit also changes treats any IList<byte> value as a !!binary value for the Yaml11 schema. Previously it only treated byte[] arrays.