### PR TITLE
Provide workaround for import problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.0 - TBD
 
 + Updated [YamlDotNet](https://github.com/aaubry/YamlDotNet) dependency to `13.7.1`
++ Provide workaround when importing the module more than once
 
 ## v0.2.1 - 2023-10-13
 

--- a/module/Yayaml.psm1
+++ b/module/Yayaml.psm1
@@ -5,11 +5,29 @@
 # an ALC for the moulde and any dependencies of that module to be loaded in
 # that ALC.
 
-$moduleName = [System.IO.Path]::GetFileNameWithoutExtension($PSCommandPath)
-Add-Type -Path ([System.IO.Path]::Combine($PSScriptRoot, 'bin', 'net6.0', "$moduleName.dll"))
+$isReload = $true
+if (-not ('Yayaml.LoadContext' -as [type])) {
+    $isReload = $false
+    $moduleName = [System.IO.Path]::GetFileNameWithoutExtension($PSCommandPath)
+    Add-Type -Path ([System.IO.Path]::Combine($PSScriptRoot, 'bin', 'net6.0', "$moduleName.dll"))
+}
 
 $mainModule = [Yayaml.LoadContext]::Initialize()
-Import-Module -Assembly $mainModule
+$alcModule = Import-Module -Assembly $mainModule -PassThru
+
+if ($isReload) {
+    # Bug in pwsh, Import-Module in an assembly will pick up a cached instance
+    # and not call the same path to set the nested module's cmdlets to the
+    # current module scope.
+    # https://github.com/PowerShell/PowerShell/issues/20710
+    $addExportedCmdlet = [System.Management.Automation.PSModuleInfo].GetMethod(
+        'AddExportedCmdlet',
+        [System.Reflection.BindingFlags]'Instance, NonPublic'
+    )
+    foreach ($cmd in $alcModule.ExportedCommands.Values) {
+        $addExportedCmdlet.Invoke($ExecutionContext.SessionState.Module, @(, $cmd))
+    }
+}
 
 # Use this for testing that the dlls are loaded correctly and outside the Default ALC.
 # [System.AppDomain]::CurrentDomain.GetAssemblies() |


### PR DESCRIPTION
When a user imports this module more than once with -Force PowerShell will fail to populate the ExportedCommands breaking the module. This provides a workaround to avoid this issue until the problem is fixed in PowerShell https://github.com/PowerShell/PowerShell/issues/20710.

Fixes: https://github.com/jborean93/PowerShell-Yayaml/issues/11