### PR TITLE
Add support for Windows PowerShell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,17 +63,26 @@ jobs:
       fail-fast: false
       matrix:
         info:
+        - name: PS_5.1_x64_Windows
+          psversion: '5.1'
+          os: windows-latest
         - name: PS_7.2_x64_Windows
-          psversion: '7.2.8'
+          psversion: '7.2.0'
           os: windows-latest
         - name: PS_7.2_x64_Linux
-          psversion: '7.2.8'
+          psversion: '7.2.0'
           os: ubuntu-latest
         - name: PS_7.3_x64_Windows
-          psversion: '7.3.1'
+          psversion: '7.3.0'
           os: windows-latest
         - name: PS_7.3_x64_Linux
-          psversion: '7.3.1'
+          psversion: '7.3.0'
+          os: ubuntu-latest
+        - name: PS_7.4_x64_Windows
+          psversion: '7.4.0'
+          os: windows-latest
+        - name: PS_7.4_x64_Linux
+          psversion: '7.4.0'
           os: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 + Updated [YamlDotNet](https://github.com/aaubry/YamlDotNet) dependency to `13.7.1`
 + Provide workaround when importing the module more than once
++ Add support for Windows PowerShell 5.1
+  + There are no guarantees that YamlDotNet will be loadable in case of conflicts, use PowerShell 7 so an ALC can be used
 
 ## v0.2.1 - 2023-10-13
 

--- a/PowerShell-Yayaml.sln
+++ b/PowerShell-Yayaml.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{32EF6859-C1AA-4118-AFC3-811DE164F574}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yayaml", "src\Yayaml\Yayaml.csproj", "{598D032C-2373-4292-94DD-DFE934C57A3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yayaml.Module", "src\Yayaml.Module\Yayaml.Module.csproj", "{4E17AD64-871F-4344-A60F-35408CD96C8E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{598D032C-2373-4292-94DD-DFE934C57A3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{598D032C-2373-4292-94DD-DFE934C57A3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{598D032C-2373-4292-94DD-DFE934C57A3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{598D032C-2373-4292-94DD-DFE934C57A3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E17AD64-871F-4344-A60F-35408CD96C8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E17AD64-871F-4344-A60F-35408CD96C8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E17AD64-871F-4344-A60F-35408CD96C8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E17AD64-871F-4344-A60F-35408CD96C8E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{598D032C-2373-4292-94DD-DFE934C57A3A} = {32EF6859-C1AA-4118-AFC3-811DE164F574}
+		{4E17AD64-871F-4344-A60F-35408CD96C8E} = {32EF6859-C1AA-4118-AFC3-811DE164F574}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F31C0D6D-8FFD-44FD-9607-D8BD49E9747D}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ While there are a few other YAML modules out on the gallery this module includes
 + YAML 1.2 JSON parser and emitter
 + Support for custom schemas
 + Finer control over scalar, map, and sequence styles
-+ Loads `YamlDotNet` in an Assembly Load Context to avoid DLL hell and cross assembly conflicts
++ Loads `YamlDotNet` in an Assembly Load Context to avoid DLL hell and cross assembly conflicts (PowerShell 7+ only)
 
 There are schemas that support YAML 1.2 (default), 1.2 JSON, 1.1, and failsafe values.
 
@@ -22,7 +22,7 @@ See [Yayaml index](docs/en-US/Yayaml.md) for more details.
 
 These cmdlets have the following requirements
 
-* PowerShell v7.2 or newer
+* PowerShell v5.1 or newer
 
 ## Examples
 

--- a/Yayaml.build.ps1
+++ b/Yayaml.build.ps1
@@ -21,7 +21,12 @@ $UseNativeArguments = $PSVersionTable.PSVersion.Major -gt 7 -or ($PSVersionTable
 [xml]$csharpProjectInfo = Get-Content ([IO.Path]::Combine($CSharpPath, '*.csproj'))
 $TargetFrameworks = @(@($csharpProjectInfo.Project.PropertyGroup)[0].TargetFrameworks.Split(
         ';', [StringSplitOptions]::RemoveEmptyEntries))
-$PSFramework = $TargetFrameworks[0]
+$PSFramework = if ($IsCoreCLR) {
+    $TargetFrameworks[1]
+}
+else {
+    $TargetFrameworks[0]
+}
 
 task Clean {
     if (Test-Path $ReleasePath) {
@@ -86,7 +91,7 @@ task CopyToRelease {
 task Sign {
     $vaultName = $env:AZURE_KEYVAULT_NAME
     $vaultCert = $env:AZURE_KEYVAULT_CERT
-    if (-not $vaultName -or -not $vaultCert) {
+    if (-not $vaultName -or -not $vaultCert -or -not $IsCoreCLR) {
         return
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -18,6 +18,11 @@ end {
     $modulePath = [IO.Path]::Combine($PSScriptRoot, 'tools', 'Modules')
     $requirements = Import-PowerShellDataFile ([IO.Path]::Combine($PSScriptRoot, 'requirements-dev.psd1'))
     foreach ($req in $requirements.GetEnumerator()) {
+        # OpenAuthenticode only works for Pwsh 7+
+        if ($req.Key -eq 'OpenAuthenticode' -and -not $IsCoreCLR) {
+            continue
+        }
+
         $targetPath = [IO.Path]::Combine($modulePath, $req.Key)
 
         if (Test-Path -LiteralPath $targetPath) {

--- a/module/Yayaml.psd1
+++ b/module/Yayaml.psd1
@@ -12,7 +12,6 @@
 
     # Script module or binary module file associated with this manifest.
     RootModule = 'Yayaml.psm1'
-    # RootModule = 'bin/net6.0/Yayaml.dll'
 
     # Version number of this module.
     ModuleVersion = '0.3.0'
@@ -36,10 +35,10 @@
     Description = 'Yet Another YAML parser and writer for PowerShell'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '7.2'
+    PowerShellVersion = '5.1'
 
     # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-    # DotNetFrameworkVersion = '4.7.2'
+    DotNetFrameworkVersion = '4.7.2'
 
     # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
     # ClrVersion = '4.0'

--- a/src/Yayaml.Module/AddYamlFormat.cs
+++ b/src/Yayaml.Module/AddYamlFormat.cs
@@ -29,10 +29,7 @@ public sealed class AddYamlFormatCommand : PSCmdlet
             return;
         }
 
-        YayamlFormat format = new(
-            CollectionStyle: CollectionStyle,
-            ScalarStyle: ScalarStyle
-        );
+        YayamlFormat format = new(CollectionStyle, ScalarStyle);
         InputObject.Properties.Add(new PSNoteProperty(SchemaHelpers.YAYAML_FORMAT_ID, format));
 
         if (PassThru)

--- a/src/Yayaml.Module/ConvertFromYaml.cs
+++ b/src/Yayaml.Module/ConvertFromYaml.cs
@@ -30,7 +30,11 @@ public sealed class ConvertFromYamlCommand : PSCmdlet
     public SwitchParameter NoEnumerate { get; set; }
 
     [Parameter]
+#if CORE
     [YamlSchemaCompletions]
+#else
+    [ArgumentCompleter(typeof(YamlSchemaCompletionsAttribute))]
+#endif
     [SchemaParameterTransformer]
     public YamlSchema? Schema { get; set; }
 

--- a/src/Yayaml.Module/ConvertToYaml.cs
+++ b/src/Yayaml.Module/ConvertToYaml.cs
@@ -38,7 +38,11 @@ public sealed class ConvertToYamlCommand : PSCmdlet
     public SwitchParameter IndentSequence { get; set; }
 
     [Parameter]
+#if CORE
     [YamlSchemaCompletions]
+#else
+    [ArgumentCompleter(typeof(YamlSchemaCompletionsAttribute))]
+#endif
     [SchemaParameterTransformer]
     public YamlSchema? Schema { get; set; }
 
@@ -285,7 +289,7 @@ internal sealed class YamlConverter
         };
         if (!string.IsNullOrWhiteSpace(value.Tag))
         {
-            node.Tag = new(value.Tag);
+            node.Tag = new(value.Tag!);
         }
 
         return node;

--- a/src/Yayaml.Module/NewYamlSchema.cs
+++ b/src/Yayaml.Module/NewYamlSchema.cs
@@ -28,7 +28,11 @@ public sealed class NewYamlSchemaCommand : PSCmdlet
     public SequenceParser? ParseSequence { get; set; }
 
     [Parameter]
+#if CORE
     [YamlSchemaCompletions]
+#else
+    [ArgumentCompleter(typeof(YamlSchemaCompletionsAttribute))]
+#endif
     [SchemaParameterTransformer]
     public YamlSchema? BaseSchema { get; set; }
 

--- a/src/Yayaml.Module/ReflectionHelper.cs
+++ b/src/Yayaml.Module/ReflectionHelper.cs
@@ -49,7 +49,9 @@ internal static class ReflectionHelper
             MethodInfo spanToArrayMeth = spanType.GetMethod(
                 "ToArray",
                 BindingFlags.Public | BindingFlags.Instance,
-                Array.Empty<Type>()
+                null,
+                Array.Empty<Type>(),
+                null
             )!;
 
             const string invokeMethName = "Invoke";

--- a/src/Yayaml.Module/Yayaml.Module.csproj
+++ b/src/Yayaml.Module/Yayaml.Module.csproj
@@ -1,13 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>$(DefineConstants);CORE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
     <ProjectReference Include="../Yayaml/Yayaml.csproj" />
   </ItemGroup>

--- a/src/Yayaml/LoadContext.cs
+++ b/src/Yayaml/LoadContext.cs
@@ -1,9 +1,8 @@
+#if CORE
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-
-[assembly: InternalsVisibleTo("Yayaml.Module")]
 
 namespace Yayaml;
 
@@ -69,3 +68,4 @@ public class LoadContext : AssemblyLoadContext
         }
     }
 }
+#endif

--- a/src/Yayaml/Nullable.cs
+++ b/src/Yayaml/Nullable.cs
@@ -1,0 +1,20 @@
+#if !CORE
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+}
+
+#endif

--- a/src/Yayaml/Yaml11Schema.cs
+++ b/src/Yayaml/Yaml11Schema.cs
@@ -400,7 +400,7 @@ $)
                 rawValue = rawValue.Substring(1);
             }
 
-            string[] integerSplit = rawValue.Split('.', 2);
+            string[] integerSplit = rawValue.Split(new [] { '.' }, 2);
             BigInteger integer = SchemaHelpers.ParseIntSexagesimal(integerSplit[0]);
             if (isNegative)
             {

--- a/src/Yayaml/YamlSchema.cs
+++ b/src/Yayaml/YamlSchema.cs
@@ -56,7 +56,17 @@ public class YamlSchema
     internal static YamlSchema CreateDefault() => new Yaml12Schema();
 }
 
-internal record YayamlFormat(CollectionStyle CollectionStyle, ScalarStyle ScalarStyle);
+internal class YayamlFormat
+{
+    public CollectionStyle CollectionStyle { get; }
+    public ScalarStyle ScalarStyle { get; }
+
+    public YayamlFormat(CollectionStyle collectionStyle, ScalarStyle scalarStyle)
+    {
+        CollectionStyle = collectionStyle;
+        ScalarStyle = scalarStyle;
+    }
+}
 
 internal static class SchemaHelpers
 {

--- a/src/Yayaml/Yayaml.csproj
+++ b/src/Yayaml/Yayaml.csproj
@@ -1,11 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>$(DefineConstants);CORE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Yayaml.Module" />
   </ItemGroup>
 </Project>

--- a/tests/ConvertFrom-Yaml.Tests.ps1
+++ b/tests/ConvertFrom-Yaml.Tests.ps1
@@ -180,7 +180,7 @@ list:
 
             $actual = (ConvertFrom-Yaml -InputObject $Value -Schema Yaml11).foo
             Should -ActualValue $actual -BeOfType ([byte[]])
-            [System.Convert]::ToHexString($actual) | Should -Be $Expected
+            -join ($actual | ForEach-Object ToString X2) | Should -Be $Expected
         }
         It "Parses bool <Value>" -TestCases @(
             @{Value = 'n'; Expected = $false}
@@ -336,6 +336,10 @@ list:
             @{Value = '.NAN'; Expected = [Double]::NaN}
         ) {
             param ($Value, $Expected)
+
+            if (-not $IsCoreCLR -and $Value -in @('2.0E+1000', '-2.0E+1000')) {
+                Set-ItResult -Skipped -Because "PowerShell can't handle doubles of this size"
+            }
 
             $actual = ConvertFrom-Yaml -InputObject $Value -Schema Yaml11
             if ($Expected.ToString() -eq 'NaN') {
@@ -575,6 +579,10 @@ dict:
         ) {
             param ($Value, $Expected)
 
+            if (-not $IsCoreCLR -and $Value -in @('2e+1000', '-2e+1000')) {
+                Set-ItResult -Skipped -Because "PowerShell can't handle doubles of this size"
+            }
+
             $actual = ConvertFrom-Yaml -InputObject $Value
             if ($Expected.ToString() -eq 'NaN') {
                 # Normal comparison doesn't work with NaN
@@ -752,6 +760,10 @@ dict:
             @{Value = '!!float .nan'; Expected = [Double]::NaN}
         ) {
             param ($Value, $Expected)
+
+            if (-not $IsCoreCLR -and $Value -in @('2e+1000', '-2e+1000')) {
+                Set-ItResult -Skipped -Because "PowerShell can't handle doubles of this size"
+            }
 
             $actual = ConvertFrom-Yaml -InputObject $Value -Schema Yaml12JSON
             if ($Expected.ToString() -eq 'NaN') {

--- a/tests/ConvertTo-Yaml.Tests.ps1
+++ b/tests/ConvertTo-Yaml.Tests.ps1
@@ -103,9 +103,9 @@ Describe "ConvertTo-Yaml" {
             @{Value = [IntPtr]::Zero; Expected = 0}
             @{Value = [UIntPtr]::Zero; Expected = 0}
             @{Value = [IntPtr]1; Expected = 1}
-            @{Value = [UIntPtr]1; Expected = 1}
+            @{Value = [UIntPtr][UInt32]1; Expected = 1}
             @{Value = [IntPtr]2147483647; Expected = 2147483647}
-            @{Value = [UIntPtr]4294967295; Expected = 4294967295}
+            @{Value = [UIntPtr][UInt32]4294967295; Expected = 4294967295}
         ) {
             param ($Value, $Expected)
             $actual = ConvertTo-Yaml $Value
@@ -213,7 +213,7 @@ Describe "ConvertTo-Yaml" {
             $actual | Should -Be "mem:$n- 1$n- 2"
         }
 
-        It "Emits Span and ReadOnlySpan properties" {
+        It "Emits Span and ReadOnlySpan properties" -Skip:(-not $IsCoreCLR) {
             Add-Type -TypeDefinition @'
 using System;
 

--- a/tools/PesterTest.ps1
+++ b/tools/PesterTest.ps1
@@ -23,6 +23,10 @@ $ErrorActionPreference = 'Stop'
 
 $requirements = Import-PowerShellDataFile ([IO.Path]::Combine($PSScriptRoot, '..', 'requirements-dev.psd1'))
 foreach ($req in $requirements.GetEnumerator()) {
+    if ($req.Key -eq 'OpenAuthenticode' -and -not $IsCoreCLR) {
+        continue
+    }
+
     Import-Module -Name ([IO.Path]::Combine($PSScriptRoot, 'Modules', $req.Key))
 }
 


### PR DESCRIPTION
Adds limited support for Windows PowerShell. This loads the module in the normal app domain so has no support for an ALC to load the YAML dependencies. While not ideal it gives users a migration route in case they are stuck on 5.1 for now.

Support for WinPS is limited, no extra work is in place to resolve any assembly conflicts and I don't plan on doing so any time soon.

Fixes: https://github.com/jborean93/PowerShell-Yayaml/issues/2