### PR TITLE
Add support for serializing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 + Updated [YamlDotNet](https://github.com/aaubry/YamlDotNet) dependency to `15.3.0`
 + Added the `-Stream` parameter to `ConvertTo-Yaml` that can serialize the input objects as they are received rather than as one big object at the end
 + Implement new emitter logic to skip the multiple processing passes done on the objects to be serialized
++ Add support for serializing values with a pre, inline, or post comment
 
 ## v0.4.0 - 2023-04-19
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ While there are a few other YAML modules out on the gallery this module includes
 + Support for custom schemas
 + Finer control over scalar, map, and sequence styles
 + Loads `YamlDotNet` in an Assembly Load Context to avoid DLL hell and cross assembly conflicts (PowerShell 7+ only)
++ Support for emitting comments in `ConvertTo-Yaml` (does not support parsing comments though)
 
 There are schemas that support YAML 1.2 (default), 1.2 JSON, 1.1, and failsafe values.
+Please note that this module does not support roundtrip representation of the input YAML format.
+Support for this may be added in the future if there is demand for it.
 
 See [Yayaml index](docs/en-US/Yayaml.md) for more details.
 

--- a/docs/en-US/Add-YamlFormat.md
+++ b/docs/en-US/Add-YamlFormat.md
@@ -14,7 +14,8 @@ Adds formatting info for use with `ConvertTo-Yaml` to an object.
 
 ```
 Add-YamlFormat [-InputObject] <PSObject> [-ScalarStyle <ScalarStyle>] [-CollectionStyle <CollectionStyle>]
- [-PassThru] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-PassThru] [-Comment <String>] [-PreComment <String>] [-PostComment <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,6 +71,26 @@ PS C:\> $obj | ConvertTo-Yaml
 Sets the dictionary like value to be emitted as a flow collection.
 Unlike the string type, `-PassThru` isn't needed for this to work although it can still be used if desired.
 
+### Example 3 - Add comments to the serialized YAML string
+```powershell
+PS C:\> $obj = [Ordered]@{
+    Key1 = 'value' | Add-YamlFormat -PreComment "Comment before key" -PassThru
+    Key2 = 'value' | Add-YamlFormat -Comment "Comment inline" -PassThru
+    Key3 = 'value' | Add-YamlFormat -PostComment "Comment after key" -PassThru
+    Key4 = 'value'
+}
+PS C:\> $obj | ConvertTo-Yaml
+# # Comment before key
+# Key1: value
+# Key2: value # Comment inline
+# Key3: value
+# # Comment after key
+# Key4: value
+```
+
+Adds comments to an object for serialization.
+See [about_YamlEmitting](./about_YamlEmitting.md) for more details around how comments are serialized and the rules around them.
+
 ## PARAMETERS
 
 ### -CollectionStyle
@@ -87,6 +108,23 @@ Type: CollectionStyle
 Parameter Sets: (All)
 Aliases:
 Accepted values: Any, Block, Flow
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Comment
+Serializes the input value with an inline comment.
+An inline comment is a comment placed at the end of the value.
+See [about_YamlEmitting](./about_YamlEmitting.md) for more information around comment serialization.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -119,6 +157,38 @@ Strings especially can be problematic as they need to be implicitly wrapped as a
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PostComment
+Serializes the input value with a comment placed after the value on the newline.
+See [about_YamlEmitting](./about_YamlEmitting.md) for more information around comment serialization.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreComment
+Serializes the input value with a comment placed before the value with the value on the next line after the comment.
+See [about_YamlEmitting](./about_YamlEmitting.md) for more information around comment serialization.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/about_YamlEmitting.md
+++ b/docs/en-US/about_YamlEmitting.md
@@ -82,3 +82,206 @@ ConvertTo-Yaml @{
 ```yaml
 null: abc
 ```
+
+## Comments
+It is possible to emit comments alongside an object when using `ConvertTo-Yaml`.
+Comments cannot be parsed through `ConvertFrom-Yaml`, the only way to emit a comment is by explicitly adding it to the object metadata before calling `ConvertTo-Yaml`.
+Comments come in three forms:
+
++ Pre - Added on the preceding line of the value
++ Inline - Added at the end of the line of the value
++ Post - Added on the next line of the value
+
+Each of these comments can be added through the [Add-YamlFormat](./Add-YamlFormat.md) cmdlet through the `-PreComment`, `-Comment`, and `-PostComment` parameters respectively.
+
+Due to the YAML parsing rules, there are some cases where comments may not be supported, for example:
+
++ Folded or Literal scalar values cannot have an inline comment
++ Flow maps/sequences (dicts/lists) will ingore any comments in any child values, the map/sequence itself can still have a pre, inline, and post comment though
++ Block maps/sequences cannot have an inline comment, the comment should be set on the inner value that is desired instead
++ Map (dicts) keys cannot have comments applied, they should be set on the value instead
+
+Here is an example of how a pre, inline, and post comment works on a simple scalar value:
+
+```powershell
+$value = 'value' | Add-YamlFormat -PreComment pre -Comment inline -PostComment post -PassThru
+$value | ConvertTo-Yaml
+```
+
+```yaml
+# pre
+value # inline
+# post
+```
+
+Attempting to set an inline comment on a folded or literal scalar will emit a warning
+
+```powershell
+$value = 'value' | Add-YamlFormat -PreComment pre -Comment inline -PostComment post -PassThru -ScalarStyle Literal
+$value | ConvertTo-Yaml
+# WARNING: Scalar value 'value' has a style of Literal and contained inline comment but will be ignored. Inline comment cannot be used for the Folded or Literal scalar values.
+```
+
+```yaml
+# pre
+|-
+  value
+# post
+```
+
+The same logic applies when serializing a scalar value inside a map or sequence.
+
+```powershell
+$value = [Ordered]@{
+    Map = [Ordered]@{
+        First = 'first'
+        Key = 'value' | Add-YamlFormat -PreComment pre -Comment inline -PostComment post -PassThru
+        Last = 'last'
+    }
+    Sequence = @(
+        'first'
+        'value' | Add-YamlFormat -PreComment pre -Comment inline -PostComment post -PassThru
+        'last'
+    )
+}
+$value | ConvertTo-Yaml
+```
+
+```yaml
+Map:
+  First: first
+  # pre
+  Key: value # inline
+  # post
+  Last: last
+Sequence:
+- first
+# pre
+- value # inline
+# post
+- last
+```
+
+When adding a comment to a map/dict value itself, it can contain a pre and post comment but not an inline comment.
+For example this is how the pre/post comments work alongside a key that also has a pre/post comment.
+
+```powershell
+$value = [Ordered]@{
+    First = 'value' | Add-YamlFormat -PreComment "value pre" -PostComment "value post" -PassThru
+}
+$value | Add-YamlFormat -PreComment "map pre" -PostComment "map post"
+$value | ConvertTo-Yaml
+```
+
+```yaml
+# map pre
+# value pre
+First: value
+# value post
+# map post
+```
+
+A flow map/dict will ignore any comments in the child values but can have an inline comment on it.
+The comment rules work similar to a scalar value where the inline comment comes after the flow map.
+
+```powershell
+$value = [Ordered]@{
+    First = 'value' | Add-YamlFormat -PreComment "value pre" -Comment "value inline" -PostComment "value post" -PassThru
+}
+$value | Add-YamlFormat -PreComment "map pre" -Comment "map inline" -PostComment "map post" -CollectionStyle Flow
+$value | ConvertTo-Yaml
+```
+
+```yaml
+# map pre
+{First: value} # map inline
+# map post
+```
+
+The same restrictions also apply to sequences where a block sequence cannot have an inline comment while flow sequences will ignore any comment inside the sequence itself.
+
+```powershell
+$block = @(
+    'first'
+    'value block' | Add-YamlFormat -PreComment "value block pre" -Comment "value block inline" -PostComment "value block post" -PassThru
+    'last'
+)
+Add-YamlFormat -InputObject $block -PreComment "block pre" -PostComment "block post"
+
+$flow = @(
+    'first'
+    'value flow' | Add-YamlFormat -PreComment "value flow pre" -Comment "value flow inline" -PostComment "value flow post" -PassThru
+    'last'
+)
+Add-YamlFormat -InputObject $flow -PreComment "flow pre" -Comment "flow inline" -PostComment "flow post" -CollectionStyle Flow
+$value = [Ordered]@{ Block = $block; Flow = $flow }
+ConvertTo-Yaml $value
+```
+
+```yaml
+# block pre
+Block:
+- first
+# value block pre
+- value block # value block inline
+# value block post
+- last
+# block post
+# flow pre
+Flow: [first, value flow, last] # flow inline
+# flow post
+```
+
+If you wish to apply a comment to all instances of a specific type, you can combine custom schema emit transformer with `Add-YamlFormat` to add the comment.
+For example:
+
+```powershell
+class MyClass {
+    [int]$Id
+    [string]$Title
+    [Object]$MetaData
+}
+
+$schema = New-YamlSchema -EmitTransformer {
+    param ($Value, $Schema)
+
+    if ($Value -is [MyClass]) {
+        $meta = $Value.MetaData | Add-YamlFormat -Comment "type: $($Value.MetaData.GetType().Name)" -PassThru
+        $obj = [Ordered]@{
+            Title = $Value.Title
+            MetaData = $meta
+        }
+        $obj | Add-YamlFormat -PreComment "id: $($Value.Id)"
+
+        $obj
+    }
+    else {
+        $Schema.EmitTransformer($Value)
+    }
+}
+
+@(
+    [MyClass]@{
+        Id = 1
+        Title = 'Foo'
+        MetaData = 'meta'
+    }
+    [MyClass]@{
+        Id = 2
+        Title = 'Bar'
+        MetaData = 1
+    }
+) | ConvertTo-Yaml -Schema $schema
+```
+
+```yaml
+# id: 1
+- Title: Foo
+  MetaData: meta # type: String
+# id: 2
+- Title: Bar
+  MetaData: 1 # type: Int32
+```
+
+In the above example we use a custom transformer to emit the `Id` property as a pre comment and add the .NET type name of the `MetaData` value as an inline comment.
+As the transformer is run on each instance to serialize, it will do this transformation on any instance of that type, whether it's a root value or part of an inner map/sequence.

--- a/src/Yayaml.Module/AddYamlFormat.cs
+++ b/src/Yayaml.Module/AddYamlFormat.cs
@@ -22,9 +22,18 @@ public sealed class AddYamlFormatCommand : PSCmdlet
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    [Parameter]
+    public string? Comment { get; set; }
+
+    [Parameter]
+    public string? PreComment { get; set; }
+
+    [Parameter]
+    public string? PostComment { get; set; }
+
     protected override void ProcessRecord()
     {
-        YayamlFormat format = new(CollectionStyle, ScalarStyle);
+        YayamlFormat format = new(CollectionStyle, ScalarStyle, Comment, PreComment, PostComment);
         InputObject.Properties.Add(new PSNoteProperty(SchemaHelpers.YAYAML_FORMAT_ID, format));
 
         if (PassThru)

--- a/src/Yayaml/YamlSchema.cs
+++ b/src/Yayaml/YamlSchema.cs
@@ -63,11 +63,22 @@ internal class YayamlFormat
 {
     public CollectionStyle CollectionStyle { get; }
     public ScalarStyle ScalarStyle { get; }
+    public string? Comment { get; }
+    public string? PreComment { get; }
+    public string? PostComment { get; }
 
-    public YayamlFormat(CollectionStyle collectionStyle, ScalarStyle scalarStyle)
+    public YayamlFormat(
+        CollectionStyle collectionStyle,
+        ScalarStyle scalarStyle,
+        string? comment,
+        string? preComment,
+        string? postComment)
     {
         CollectionStyle = collectionStyle;
         ScalarStyle = scalarStyle;
+        Comment = comment;
+        PreComment = preComment;
+        PostComment = postComment;
     }
 }
 

--- a/tests/Add-YamlFormat.Tests.ps1
+++ b/tests/Add-YamlFormat.Tests.ps1
@@ -1,0 +1,12 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+$global:n = [System.Environment]::NewLine
+
+Describe "Add-YamlFormat" {
+    It "Emits error when using null as input" {
+        $actual = $null | Add-YamlFormat -ScalarStyle DoubleQuoted -ErrorAction SilentlyContinue -ErrorVariable err
+        $actual | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        [string]$err[0] | Should -Be "Cannot bind argument to parameter 'InputObject' because it is null."
+    }
+}


### PR DESCRIPTION
This commit adds the ability to serialize comments with the ConvertTo-Yaml cmdlet. Comments are added to the value using the Add-YamlFormat cmdlet.