### PR TITLE
Add Tag property to map and sequence values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
       shell: pwsh
       run: ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Build
       env:
-        AZURE_KEYVAULT_NAME: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_KEYVAULT_NAME || '' }}
-        AZURE_KEYVAULT_CERT: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_KEYVAULT_CERT || '' }}
+        AZURE_TS_NAME: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_TS_NAME || '' }}
+        AZURE_TS_PROFILE: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_TS_PROFILE || '' }}
+        AZURE_TS_ENDPOINT: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_TS_ENDPOINT || '' }}
 
     - name: Capture PowerShell Module
       uses: actions/upload-artifact@v4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,34 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "PowerShell launch",
-            "type": "coreclr",
-            "request": "launch",
-            "program": "pwsh",
-            "args": [
-                "-NoExit",
-                "-NoProfile",
-                "-Command",
-                "Import-Module ./output/Yayaml"
-            ],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "console": "integratedTerminal",
-            "justMyCode": false
-        },
-        {
-            "name": "PowerShell Launch Current File",
+            "name": "PowerShell: Binary Module Interactive",
             "type": "PowerShell",
             "request": "launch",
-            "script": "${file}",
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "name": ".NET CoreCLR Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}",
-            "justMyCode": true,
+            "script": "Import-Module ./output/Yayaml; $host.EnterNestedPrompt()",
+            "createTemporaryIntegratedConsole": true,
+            "attachDotnetDebugger": true
         },
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     // Binary modules cannot be unloaded so running in separate processes solves that problem
     //"powershell.debugging.createTemporaryIntegratedConsole": true,
     // We use Pester v5 so we don't need the legacy code lens
+    "powershell.pester.codeLens": true,
     "powershell.pester.useLegacyCodeLens": false,
     "powershell.debugging.createTemporaryIntegratedConsole": true,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog for Yayaml
 
+## v0.7.0 - TBD
+
++ Added the `Tag` property to the emitted `MapValue` and `SequenceValue` for the `-Parse*` APIs on a YAML schema
+
 ## v0.6.0 - 2025-03-13
 
 + Updated [YamlDotNet](https://github.com/aaubry/YamlDotNet) dependency to `16.3.0`
-+ Raised minimum PowerSHell 7 version to 7.4
++ Raised minimum PowerShell 7 version to 7.4
 
 ## v0.5.0 - 2024-07-11
 

--- a/manifest.psd1
+++ b/manifest.psd1
@@ -1,6 +1,6 @@
 @{
     DotnetProject = 'Yayaml.Module'
-    InvokeBuildVersion = '5.12.1'
+    InvokeBuildVersion = '5.14.14'
     PesterVersion = '5.7.1'
     BuildRequirements = @(
         @{
@@ -9,7 +9,7 @@
         }
         @{
             ModuleName = 'OpenAuthenticode'
-            RequiredVersion = '0.6.1'
+            RequiredVersion = '0.6.2'
         }
         @{
             ModuleName = 'platyPS'

--- a/module/Yayaml.psd1
+++ b/module/Yayaml.psd1
@@ -14,7 +14,7 @@
     RootModule = 'Yayaml.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.6.0'
+    ModuleVersion = '0.7.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Yayaml.Module/ConvertFromYaml.cs
+++ b/src/Yayaml.Module/ConvertFromYaml.cs
@@ -148,6 +148,7 @@ public sealed class ConvertFromYamlCommand : PSCmdlet
         {
             Values = res,
             Style = (CollectionStyle)node.Style,
+            Tag = node.Tag.ToString(),
         });
     }
 
@@ -163,6 +164,7 @@ public sealed class ConvertFromYamlCommand : PSCmdlet
         return schema.ParseSequence(new SequenceValue(res.ToArray())
         {
             Style = (CollectionStyle)node.Style,
+            Tag = node.Tag.ToString(),
         });
     }
 

--- a/src/Yayaml.Module/Yayaml.Module.csproj
+++ b/src/Yayaml.Module/Yayaml.Module.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Yayaml/YamlValue.cs
+++ b/src/Yayaml/YamlValue.cs
@@ -34,6 +34,11 @@ public sealed class MapValue
     /// </summary>
     public CollectionStyle Style { get; set; }
 
+    /// <summary>
+    /// The mapping tag if set.
+    /// </summary>
+    public string? Tag { get; set; }
+
     public MapValue()
     {
         Values = new Hashtable();
@@ -77,6 +82,11 @@ public sealed class SequenceValue
     /// The sequence style.
     /// </summary>
     public CollectionStyle Style { get; set; } = CollectionStyle.Any;
+
+    /// <summary>
+    /// The sequence tag if set.
+    /// </summary>
+    public string? Tag { get; set; }
 
     public SequenceValue()
         : this(Array.Empty<object?>())

--- a/src/Yayaml/Yayaml.csproj
+++ b/src/Yayaml/Yayaml.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/tests/ConvertFrom-Yaml.Tests.ps1
+++ b/tests/ConvertFrom-Yaml.Tests.ps1
@@ -918,11 +918,11 @@ dict:
                 , $res
             }
 
-            $actual = ConvertFrom-Yaml -InputObject "!custom`n- foo`n- bar" -Schema $schema -NoEnumerate
-            $actual.Count | Should -Be 2
-            $actual[0] | Should -Be 'foo'
-            $actual[1] | Should -Be 'bar'
-            $actual.Tag | Should -Be !custom
+            $actual = ConvertFrom-Yaml -InputObject "key: !custom`n- foo`n- bar" -Schema $schema
+            $actual.key.Count | Should -Be 2
+            $actual.key[0] | Should -Be 'foo'
+            $actual.key[1] | Should -Be 'bar'
+            $actual.key.Tag | Should -Be !custom
         }
 
         It "Parses with custom map" {

--- a/tests/ConvertFrom-Yaml.Tests.ps1
+++ b/tests/ConvertFrom-Yaml.Tests.ps1
@@ -891,6 +891,40 @@ dict:
             $actual['?|Plain|other'] | Should -Be '?|SingleQuoted|quoted'
         }
 
+        It "Parses mapping with custom tag handler" {
+            $schema = New-YamlSchema -ParseMap {
+                param ($Values, $Schema)
+
+                $res = $Schema.ParseMap($Values)
+                $res.PSObject.Properties.Add([PSNoteProperty]::new('Tag', $Values.Tag))
+
+                $res
+            }
+
+            $actual = ConvertFrom-Yaml -InputObject "!custom`n  key1: 1`n  key2: 2" -Schema $schema
+            $actual.Count | Should -Be 2
+            $actual.key1 | Should -Be 1
+            $actual.key2 | Should -Be 2
+            $actual.Tag | Should -Be !custom
+        }
+
+        It "Parses sequence with custom tag handler" {
+            $schema = New-YamlSchema -ParseSequence {
+                param ($Values, $Schema)
+
+                $res = $Schema.ParseSequence($Values)
+                $res.PSObject.Properties.Add([PSNoteProperty]::new('Tag', $Values.Tag))
+
+                , $res
+            }
+
+            $actual = ConvertFrom-Yaml -InputObject "!custom`n- foo`n- bar" -Schema $schema -NoEnumerate
+            $actual.Count | Should -Be 2
+            $actual[0] | Should -Be 'foo'
+            $actual[1] | Should -Be 'bar'
+            $actual.Tag | Should -Be !custom
+        }
+
         It "Parses with custom map" {
             $schema = New-YamlSchema -ParseMap {
                 param ($Value, $Schema)

--- a/tools/InvokeBuild.ps1
+++ b/tools/InvokeBuild.ps1
@@ -63,17 +63,23 @@ task BuildDocs {
 }
 
 task Sign {
-    $vaultName = $env:AZURE_KEYVAULT_NAME
-    $vaultCert = $env:AZURE_KEYVAULT_CERT
-    if (-not $vaultName -or -not $vaultCert) {
+    $accountName = $env:AZURE_TS_NAME
+    $profileName = $env:AZURE_TS_PROFILE
+    $endpoint = $env:AZURE_TS_ENDPOINT
+    if (-not $accountName -or -not $profileName -or -not $endpoint) {
         return
     }
 
-    Write-Host "Authenticating with Azure KeyVault '$vaultName' for signing" -ForegroundColor Cyan
-    $key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert
+    Write-Host "Authenticating with Azure TrustedSigning $accountName $profileName for signing" -ForegroundColor Cyan
+    $keyParams = @{
+        AccountName = $accountName
+        ProfileName = $profileName
+        Endpoint = $endpoint
+    }
+    $key = Get-OpenAuthenticodeAzTrustedSigner @keyParams
     $signParams = @{
         Key = $key
-        TimeStampServer = 'http://timestamp.digicert.com'
+        TimeStampServer = 'http://timestamp.acs.microsoft.com'
     }
 
     $toSign = Get-ChildItem -LiteralPath $Manifest.ReleasePath -Recurse -ErrorAction SilentlyContinue |

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -148,7 +148,7 @@ class Manifest {
     }
 }
 
-Function Assert-ModuleFast {
+function Assert-ModuleFast {
     [CmdletBinding()]
     param(
         [Parameter()]
@@ -164,7 +164,7 @@ Function Assert-ModuleFast {
     & ([scriptblock]::Create((Invoke-WebRequest -Uri 'bit.ly/modulefast'))) -Release $Version
 }
 
-Function Assert-PowerShell {
+function Assert-PowerShell {
     [OutputType([string])]
     [CmdletBinding()]
     param(
@@ -183,7 +183,7 @@ Function Assert-PowerShell {
         ARM64 { 'arm64' }
         default {
             $err = [ErrorRecord]::new(
-                [Exception]::new("Unsupported archecture requests '$_'"),
+                [Exception]::new("Unsupported architecture requests '$_'"),
                 "UnknownArch",
                 [ErrorCategory]::InvalidArgument,
                 $_
@@ -349,7 +349,7 @@ function Expand-Nupkg {
     }
 }
 
-Function Install-BuildDependencies {
+function Install-BuildDependencies {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipeline)]
@@ -376,7 +376,7 @@ Function Install-BuildDependencies {
             return
         }
 
-        Assert-ModuleFast -Version v0.2.0
+        Assert-ModuleFast -Version v0.6.0
 
         $installParams = @{
             ModulesToInstall = $modules
@@ -396,7 +396,7 @@ Function Install-BuildDependencies {
     }
 }
 
-Function Format-CoverageInfo {
+function Format-CoverageInfo {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]


### PR DESCRIPTION
Adds the `Tag` proprty to the emitting `MapValue` and `SequenceValue` used by the `-ParseMap` and `-ParseSequence` parameters on a schema. This allows the caller to preserve the YAML tag value on these types if they wish to do so.